### PR TITLE
Various work on `hoPreservesProducts`

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
@@ -132,12 +132,13 @@ instance hoFunctor.binaryProductNerveIsIso (C D : Type v) [Category.{v} C] [Cate
     exact IsIso.of_isIso_fac_right (prodComparison_comp hoFunctor nerveFunctor).symm
   apply isIso_of_fully_faithful nerveFunctor
 
+-- Note: `(Δ[n] : SSet.{w})` works, but I'm not sure it's the right thing to do here.
 /-- By `simplexIsNerve` this is isomorphic to a map of the form
 `hoFunctor.binaryProductNerveIsIso`. -/
-instance hoFunctor.binarySimplexProductIsIso (n m : ℕ) :
-    IsIso (prodComparison hoFunctor Δ[n] Δ[m]) :=
-  IsIso.of_isIso_fac_right
-    (prodComparison_natural hoFunctor (simplexIsNerve' n).hom (simplexIsNerve' m).hom).symm
+instance hoFunctor.binarySimplexProductIsIso.{w} (n m : ℕ) :
+    IsIso (prodComparison hoFunctor (Δ[n] : SSet.{w}) Δ[m]) :=
+  IsIso.of_isIso_fac_right (prodComparison_natural
+    hoFunctor (simplexIsNerveULiftFin.{w} n).hom (simplexIsNerveULiftFin m).hom).symm
 
 noncomputable
 def CartesianMonoidalCategory.tensorLeftIsoProd

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
@@ -59,15 +59,11 @@ def SimplexCategory.homEquivOrderHom {a b : SimplexCategory} :
     (a ⟶ b) ≃ (Fin (a.len + 1) →o Fin (b.len + 1)) where
   toFun := Hom.toOrderHom
   invFun := Hom.mk
-  left_inv f := by ext; rfl
-  right_inv f := by ext; rfl
 
 def OrderHom.uliftMapIso {α β : Type*} [Preorder α] [Preorder β] :
     (ULift α →o ULift β) ≃ (α →o β) where
   toFun f := ⟨fun x ↦ (f ⟨x⟩).down, fun _ _ h ↦ f.monotone (by simpa)⟩
   invFun := OrderHom.uliftMap
-  left_inv f := by ext; rfl
-  right_inv f := by ext; rfl
 
 -- set_option pp.universes true
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HoFunctorPreservesBinaryProducts.lean
@@ -49,25 +49,6 @@ lemma foo : IsIso (α.app c.pt) := by
 
 end
 
--- Where do these belong?
--- BM: `Mathlib.CategoryTheory.Category.Preorder`
-namespace OrderHom
-
-open CategoryTheory Functor SSet
-
--- BM: golfed this, at the cost of being a bit less explicit
-def toFunctor {X Y} [Preorder X] [Preorder Y] (f : X →o Y) : X ⥤ Y := f.monotone.functor
-
-def ofFunctor {X Y} [Preorder X] [Preorder Y] (F : X ⥤ Y) : (X →o Y) where
-  toFun := F.obj
-  monotone' := monotone F
-
-def isoFunctor {X Y} [Preorder X] [Preorder Y] : (X →o Y) ≅ (X ⥤ Y) where
-  hom := toFunctor
-  inv := ofFunctor
-
-end OrderHom
-
 namespace CategoryTheory
 
 universe u v

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -204,7 +204,7 @@ def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
 of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
 @[simps! functor_obj_obj inverse_obj unitIso_hom_app unitIso_inv_app counitIso_inv_app_app
   counitIso_hom_app_app]
-def equivalence : (X →o Y) ≌ (X ⥤ Y) where
+def equivalenceFunctor : (X →o Y) ≌ (X ⥤ Y) where
   functor :=
     { obj f := f.toFunctor
       map f := { app a := f.down.down a |>.hom } }

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -193,8 +193,6 @@ open CategoryTheory
 /-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
 abbrev toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
 
-variable (X Y)
-
 /-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
 `X` and `Y`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -172,49 +172,47 @@ section Preorder
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-namespace CategoryTheory
+namespace CategoryTheory.Functor
 
 /-- A functor between preorder categories is monotone. -/
 @[mono]
-theorem Functor.monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
+theorem monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
 
-end CategoryTheory
+/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
+@[simps!]
+def toOrderHom (F : X ⥤ Y) : (X →o Y) where
+  toFun := F.obj
+  monotone' := F.monotone
+
+end CategoryTheory.Functor
 
 namespace OrderHom
 
 open CategoryTheory
 
 /-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
-def toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
+abbrev toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
 
-/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
-def ofFunctor (F : X ⥤ Y) : (X →o Y) where
-  toFun := F.obj
-  monotone' := F.monotone
+variable (X Y)
 
 /-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
 `X` and `Y`. -/
+@[simps]
 def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
   toFun := toFunctor
-  invFun := ofFunctor
-
-/-- The functor from the category of monotone functions `X →o Y` to the category of functors
-`X ⥤ Y` where `X` and `Y` are preorder categories. -/
-def Functor.toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
-  obj := OrderHom.toFunctor
-  map f := { app a := f.down.down a |>.hom }
-
-/-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
-the category of monotone functions `X →o Y`. -/
-def Functor.ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
-  obj := OrderHom.ofFunctor
-  map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
+  invFun F := F.toOrderHom
 
 /-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
-of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/
+of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
+@[simps! functor_obj_obj inverse_obj unitIso_hom_app unitIso_inv_app counitIso_inv_app_app
+  counitIso_hom_app_app]
 def equivalence : (X →o Y) ≌ (X ⥤ Y) where
-  functor := Functor.toFunctor
-  inverse := Functor.ofFunctor
+  functor :=
+    { obj f := f.toFunctor
+      map f := { app a := f.down.down a |>.hom } }
+  inverse :=
+    { obj F := F.toOrderHom
+      map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩ }
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -198,21 +198,17 @@ def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
   toFun := toFunctor
   invFun := ofFunctor
 
-namespace Functor
-
 /-- The functor from the category of monotone functions `X →o Y` to the category of functors
 `X ⥤ Y` where `X` and `Y` are preorder categories. -/
-def toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
+def Functor.toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
   obj := OrderHom.toFunctor
   map f := { app a := f.down.down a |>.hom }
 
 /-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
 the category of monotone functions `X →o Y`. -/
-def ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
+def Functor.ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
   obj := OrderHom.ofFunctor
   map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
-
-end Functor
 
 /-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
 of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -171,20 +171,67 @@ def OrderIso.equivalence (e : X ≃o Y) : X ≌ Y where
 
 end
 
-namespace CategoryTheory
-
 section Preorder
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-/-- A functor between preorder categories is monotone.
--/
+namespace CategoryTheory
+
+/-- A functor between preorder categories is monotone. -/
 @[mono]
 theorem Functor.monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
+
+end CategoryTheory
+
+namespace OrderHom
+
+open CategoryTheory
+
+/-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
+def toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
+
+/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
+def ofFunctor (F : X ⥤ Y) : (X →o Y) where
+  toFun := F.obj
+  monotone' := F.monotone
+
+/-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
+`X` and `Y`. -/
+def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
+  toFun := toFunctor
+  invFun := ofFunctor
+
+namespace Functor
+
+/-- The functor from the category of monotone functions `X →o Y` to the category of functors
+`X ⥤ Y` where `X` and `Y` are preorder categories. -/
+def toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
+  obj := OrderHom.toFunctor
+  map f := { app a := f.down.down a |>.hom }
+
+/-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
+the category of monotone functions `X →o Y`. -/
+def ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
+  obj := OrderHom.ofFunctor
+  map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
+
+end Functor
+
+/-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
+of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/
+def equivalence : (X →o Y) ≌ (X ⥤ Y) where
+  functor := Functor.toFunctor
+  inverse := Functor.ofFunctor
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
+end OrderHom
 
 end Preorder
 
 section PartialOrder
+
+namespace CategoryTheory
 
 variable {X : Type u} {Y : Type v} [PartialOrder X] [PartialOrder Y]
 
@@ -214,9 +261,9 @@ theorem Equivalence.toOrderIso_symm_apply (e : X ≌ Y) (y : Y) :
     e.toOrderIso.symm y = e.inverse.obj y :=
   rfl
 
-end PartialOrder
-
 end CategoryTheory
+
+end PartialOrder
 
 open CategoryTheory
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -57,8 +57,7 @@ open Opposite
 
 variable {X : Type u} [Preorder X]
 
-/-- Express an inequality as a morphism in the corresponding preorder category.
--/
+/-- Express an inequality as a morphism in the corresponding preorder category. -/
 def homOfLE {x y : X} (h : x ≤ y) : x ⟶ y :=
   ULift.up (PLift.up h)
 
@@ -74,8 +73,7 @@ theorem homOfLE_comp {x y z : X} (h : x ≤ y) (k : y ≤ z) :
     homOfLE h ≫ homOfLE k = homOfLE (h.trans k) :=
   rfl
 
-/-- Extract the underlying inequality from a morphism in a preorder category.
--/
+/-- Extract the underlying inequality from a morphism in a preorder category. -/
 theorem leOfHom {x y : X} (h : x ⟶ y) : x ≤ y :=
   h.down.down
 
@@ -147,8 +145,7 @@ open CategoryTheory
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-/-- A monotone function between preorders induces a functor between the associated categories.
--/
+/-- A monotone function between preorders induces a functor between the associated categories. -/
 def Monotone.functor {f : X → Y} (h : Monotone f) : X ⥤ Y where
   obj := f
   map g := CategoryTheory.homOfLE (h g.le)
@@ -238,8 +235,7 @@ variable {X : Type u} {Y : Type v} [PartialOrder X] [PartialOrder Y]
 theorem Iso.to_eq {x y : X} (f : x ≅ y) : x = y :=
   le_antisymm f.hom.le f.inv.le
 
-/-- A categorical equivalence between partial orders is just an order isomorphism.
--/
+/-- A categorical equivalence between partial orders is just an order isomorphism. -/
 def Equivalence.toOrderIso (e : X ≌ Y) : X ≃o Y where
   toFun := e.functor.obj
   invFun := e.inverse.obj

--- a/Mathlib/CategoryTheory/Category/ULift.lean
+++ b/Mathlib/CategoryTheory/Category/ULift.lean
@@ -88,6 +88,11 @@ def ULiftHom.objDown {C} (A : ULiftHom C) : C :=
 def ULiftHom.objUp {C} (A : C) : ULiftHom C :=
   A
 
+/-- The type-level equivalence between `C` and `ULiftHom C`. -/
+def ULiftHom.objEquiv {C} : C ≃ ULiftHom C where
+  toFun := ULiftHom.objUp
+  invFun := ULiftHom.objDown
+
 @[simp]
 theorem objDown_objUp {C} (A : C) : (ULiftHom.objUp A).objDown = A :=
   rfl
@@ -173,9 +178,22 @@ def AsSmall.equiv : C ≌ AsSmall C where
 instance [Inhabited C] : Inhabited (AsSmall C) :=
   ⟨⟨default⟩⟩
 
+/-- The type-level equivalence between `C` and `ULiftHom (ULift C)`. -/
+def ULiftHomULiftCategory.objEquiv.{v', u', v, u} {C : Type u} [Category.{v} C] :
+    C ≃ ULiftHom.{v'} (ULift.{u'} C) :=
+  Equiv.ulift.symm.trans ULiftHom.objEquiv
+
 /-- The equivalence between `C` and `ULiftHom (ULift C)`. -/
 def ULiftHomULiftCategory.equiv.{v', u', v, u} (C : Type u) [Category.{v} C] :
     C ≌ ULiftHom.{v'} (ULift.{u'} C) :=
   ULift.equivalence.trans ULiftHom.equiv
+
+/-- A type-level equivalence `(C ⥤ D) ≃ (C ⥤ (ULiftHom.{v'} (ULift.{u'} D)))`. Note that this is
+not ensured by a categorical equivalence, and so needs special treatment. -/
+def ULiftHomULiftCategory.equivCongrLeft.{v', u'}
+    {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D] :
+    (C ⥤ D) ≃ (C ⥤ (ULiftHom.{v'} (ULift.{u'} D))) where
+  toFun F := F ⋙ ULift.upFunctor ⋙ ULiftHom.up
+  invFun F := F ⋙ ULiftHom.down ⋙ ULift.downFunctor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -890,48 +890,52 @@ section
 universe u v
 
 /-- An alias for the underlying type of the category `Fin n` lifted to an object of `Cat.{v, u}`. -/
-def ULiftFin (n : ℕ) : Type u := (ULiftHom.{u,u} (ULift.{u} (Fin n)))
+def ULiftFin (n : ℕ) : Type u := (ULiftHom.{v} (ULift.{u} (Fin n)))
 
 instance {n : ℕ} : Category (ULiftFin n) := ULiftHom.category
+
 namespace ULiftFin
 
-variable {n : ℕ} {C : Type u} [Category.{v} C]
+/-- The `Fin` underlying some `ULiftFin`. -/
+def toFin {n : ℕ} (a : ULiftFin n) : Fin n := a.objDown.down
 
-/-- A functor `ULiftFin (n + 1) ⥤ C` defines a term of type `ComposableArrows C n`. -/
-def toComposableArrows (F : ULiftFin (n + 1) ⥤ C) : ComposableArrows C n :=
-  ULift.upFunctor ⋙ ULiftHom.up ⋙ F
+/-- The type-level equivalence between `Fin n` and `ULiftFin n`. -/
+def equiv {n : ℕ} : Fin n ≃ ULiftFin n := ULiftHomULiftCategory.objEquiv
 
-/-- A term of type `ComposableArrows C n` defines a functor `ULiftFin (n + 1) ⥤ C`. -/
-def ofComposableArrows (G : ComposableArrows C n) : (ULiftFin (n + 1) ⥤ C) :=
-  ULiftHom.down (C := ULift.{u} (Fin (n + 1))) ⋙ ULift.downFunctor ⋙ G
-
-@[simp]
-theorem to_ofComposableArrows :
-    Function.LeftInverse (toComposableArrows (C := C) (n := n)) ofComposableArrows := by
-  intro
-  apply ComposableArrows.ext (by rfl_cat)
-  · intros
-    simp only [ComposableArrows.map', homOfLE_leOfHom, eqToHom_refl, comp_id, id_comp]
-    rfl
-
-@[simp]
-theorem of_toComposableArrows :
-    Function.RightInverse (toComposableArrows (C := C) (n := n)) ofComposableArrows := by
-  intro G; unfold ofComposableArrows toComposableArrows
-  refine Functor.ext_of_iso (by rfl_cat) ?_ (by rfl_cat)
-  · rw (occs := .pos [2]) [← Functor.assoc]; rfl_cat
+/-- The canonical equivalence between `Fin n` and `ULiftFin n`. -/
+def equivalence {n : ℕ} : Fin n ≌ ULiftFin n := ULiftHomULiftCategory.equiv _
 
 end ULiftFin
 
-end
+namespace ComposableArrows
 
-variable {C}
+variable {C} {n : ℕ}
 
-section
+/-- The equivalence between `ComposableArrows C n` and `ULiftFin (n + 1) ⥤ C` obtained via the
+equivalence between `Fin (n + 1)` and `ULiftFin (n + 1)`. -/
+@[simps!] def equivalenceULiftFin : ComposableArrows C n ≌ (ULiftFin (n + 1) ⥤ C) :=
+  ULiftFin.equivalence.congrLeft
+
+/-- A term of type `ComposableArrows C n` defines a functor `ULiftFin (n + 1) ⥤ C`. -/
+@[simps!] def toULiftFin (G : ComposableArrows C n) : (ULiftFin (n + 1) ⥤ C) :=
+  equivalenceULiftFin.functor.obj G
+
+/-- A functor `ULiftFin (n + 1) ⥤ C` defines a term of type `ComposableArrows C n`. -/
+@[simps!] def _root_.CategoryTheory.ULiftFin.toComposableArrows (F : ULiftFin (n + 1) ⥤ C) :
+    ComposableArrows C n :=
+  equivalenceULiftFin.inverse.obj F
+
+/-- The type-level equivalence between `ComposableArrows C n` and `ULiftFin (n + 1) ⥤ C`. -/
+@[simps]
+def equivULiftFin : ComposableArrows C n ≃ (ULiftFin (n + 1) ⥤ C) where
+  toFun := toULiftFin
+  invFun := ULiftFin.toComposableArrows
+
+end ComposableArrows
 
 open ComposableArrows
 
-variable {D : Type*} [Category D] (G : C ⥤ D) (n : ℕ)
+variable {C} {D : Type*} [Category D] (G : C ⥤ D) (n : ℕ)
 
 /-- The functor `ComposableArrows C n ⥤ ComposableArrows D n` obtained by postcomposition
 with a functor `C ⥤ D`. -/

--- a/Mathlib/CategoryTheory/PUnit.lean
+++ b/Mathlib/CategoryTheory/PUnit.lean
@@ -106,11 +106,15 @@ noncomputable def TerminalCatDiscretePUnitIso : ⊤_ Cat.{u,u} ≅ Cat.of (Discr
 
 /-- An isomorphism between `ULiftFin 1` and `Discrete PUnit`. -/
 def ULiftFinDiscretePUnitIso : Cat.of (ULiftFin 1) ≅ Cat.of (Discrete PUnit) where
-  hom := toCatHom (star (ULiftFin 1))
-  inv := toCatHom (fromPUnit (ULift.up 0))
-  hom_inv_id := by
-    apply (Function.RightInverse.injective ULiftFin.of_toComposableArrows)
-    exact ComposableArrows.ext₀ rfl
-  inv_hom_id := rfl
+  hom := toCatHom <| star (ULiftFin 1)
+  inv := toCatHom <| fromPUnit (ULift.up 0)
+  hom_inv_id :=
+    ComposableArrows.equivULiftFin.right_inv.injective (ComposableArrows.ext₀ rfl)
+
+def DiscretePUnit.equivalenceULiftFin : ULiftFin.{u} 1 ≌ Discrete.{v} PUnit where
+  functor := star (ULiftFin 1)
+  inverse := fromPUnit (ULift.up 0)
+  unitIso := NatIso.ofComponents fun ⟨0⟩ ↦ Iso.refl _
+  counitIso := Iso.refl _
 
 end CategoryTheory

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -504,6 +504,26 @@ higher universe. -/
 def uliftMap (f : α →o β) : ULift α →o ULift β :=
   ⟨fun i => ⟨f i.down⟩, fun _ _ h ↦ f.monotone h⟩
 
+/-- Lift an order homomorphism `f : α →o β` to an order homomorphism `α →o ULift β` in a
+higher universe. -/
+@[simps!]
+def uliftRightMap (f : α →o β) : α →o ULift β :=
+  ⟨fun i => ⟨f i⟩, fun _ _ h ↦ f.monotone h⟩
+
+/-- Lift an order homomorphism `f : α →o β` to an order homomorphism `ULift α →o β` in a
+higher universe. -/
+@[simps!]
+def uliftLeftMap (f : α →o β) : ULift α →o β :=
+  ⟨fun i => f i.down, fun _ _ h ↦ f.monotone h⟩
+
+@[simp]
+theorem uliftLeftMap_uliftRightMap_eq (f : α →o β) : f.uliftLeftMap.uliftRightMap = f.uliftMap :=
+  rfl
+
+@[simp]
+theorem uliftRightMap_uliftLeftMap_eq (f : α →o β) : f.uliftRightMap.uliftLeftMap = f.uliftMap :=
+  rfl
+
 end OrderHom
 
 -- See note [lower instance priority]


### PR DESCRIPTION
This PR includes various changes. From most significant to least:
- I merge the `OrderHom` API that's being upstreamed in leanprover-community/mathlib4#26415 ; I hope this will be merged soon
- I modify the `ULiftFin` API somewhat:
  - the lemmas about invertibility are merely the `left_inv` and `right_inv` of an equiv
  - Equiv(alence)s to `Fin` are added
  - a projection to `Fin` is added, but I stop short of a coercion for now
  - I add a type-level equiv between functor categories with ulifted target categories; see file
- I extend the `OrderHom` functionality around `ULift`ing just a little
- I restore `simplexIsNerve` mostly as-is, including the ulifted version
- I fix something by annotating something with `SSet.{w}`, where `w` is a new universe parameter—which *felt* right, but which I can't actually justify yet!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
